### PR TITLE
SLING-12310 Fix test compatibility with java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
     <properties>
         <project.build.outputTimestamp>2023-02-15T06:46:23Z</project.build.outputTimestamp>
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
-        <jackrabbit.version>2.14.3</jackrabbit.version>
+        <jackrabbit.version>2.20.0</jackrabbit.version>
+        <oak.version>1.22</oak.version>
     </properties>
 
     <scm>
@@ -81,6 +82,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
@@ -92,12 +100,9 @@
                 </executions>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <systemProperties>
-                        <property>
-                            <name>bundle.filename</name>
-                            <value>${basedir}/target/${project.build.finalName}.jar</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <bundle.filename>${basedir}/target/${project.build.finalName}.jar</bundle.filename>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -165,7 +170,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.11.0</version>
+            <version>2.16.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -187,20 +192,20 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.serviceusermapper</artifactId>
-            <version>1.2.0</version>
+            <version>1.4.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.paxexam</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Apache Felix -->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>6.0.3</version>
+            <version>7.0.5</version>
             <scope>test</scope>
         </dependency>
         <!-- Testing -->
@@ -212,61 +217,10 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-        <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        
-        <!-- workaround SLING-7159 - the jackrabbit version from o.a.sling.commons.testing is not compatible with java9+. 
-                remove this after the deprecated dependency to o.a.sling.commons.testing has been replaced -->
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-api</artifactId>
-            <version>${jackrabbit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- workaround SLING-7159 - the jackrabbit version from o.a.sling.commons.testing is not compatible with java9+. 
-                remove this after the deprecated dependency to o.a.sling.commons.testing has been replaced -->
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-core</artifactId>
-            <version>${jackrabbit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.testing</artifactId>
-            <version>2.1.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- slf4j simple implementation logs INFO + higher to stdout (we don't want that behaviour) -->
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-                <!-- workaround SLING-7159 - the jackrabbit version is not compatible with java9+ 
-                       so exclude these here and declare newer version of jackrabbit artifacts above. -->
-                <exclusion>
-                    <groupId>org.apache.jackrabbit</groupId>
-                    <artifactId>jackrabbit-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.jackrabbit</groupId>
-                    <artifactId>jackrabbit-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -302,11 +256,41 @@
             <version>${org.ops4j.pax.exam.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-          <version>3.0.0</version>
-          <scope>test</scope>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
+            <version>1.6.14</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <version>3.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
+            <version>3.4.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <version>3.4.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.threads</artifactId>
+            <version>3.2.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/apache/sling/i18n/it/ResourceBundleLocatorIT.java
+++ b/src/test/java/org/apache/sling/i18n/it/ResourceBundleLocatorIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.i18n.it;
 
+import static org.apache.sling.testing.paxexam.SlingOptions.slingBundleresource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.ops4j.pax.exam.CoreOptions.composite;
@@ -134,7 +135,8 @@ public class ResourceBundleLocatorIT extends I18nTestSupport {
             }
         }
         
-        return composite(composite(super.configuration()), 
+        return composite(composite(super.configuration()),
+                        slingBundleresource(),
                          composite(bundle))
                 .getOptions();
     }


### PR DESCRIPTION
Some of the tests are failing when building with java 17.  

- bump oak/jackrabbit dependencies to the oldest still supported and compatible version
- replace powermock usage with mockito
- replace dependency on org.apache.sling.commons.testing with sling mocks equivalent
- update various dependency versions to compatible versions