### PR TITLE
SLING-12312 add jakarta.servlet support in RequestLocaleResolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <artifactId>org.apache.sling.i18n</artifactId>
-    <version>2.6.3-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
 
     <name>Apache Sling I18N Support</name>
     <description>Support for creating Java I18N ResourceBundles from repository resources.</description>
@@ -122,6 +122,12 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- OSGi -->

--- a/src/main/java/org/apache/sling/i18n/DefaultLocaleResolver.java
+++ b/src/main/java/org/apache/sling/i18n/DefaultLocaleResolver.java
@@ -23,8 +23,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.sling.api.SlingHttpServletRequest;
 
 /**
@@ -41,18 +39,32 @@ public class DefaultLocaleResolver implements LocaleResolver, RequestLocaleResol
      * <code>List</code>.
      */
     public List<Locale> resolveLocale(final SlingHttpServletRequest request) {
-        return this.resolveLocale((HttpServletRequest)request);
+        return this.resolveLocale((javax.servlet.http.HttpServletRequest)request);
     }
 
     /**
      * @see org.apache.sling.i18n.RequestLocaleResolver#resolveLocale(javax.servlet.http.HttpServletRequest)
      */
-    public List<Locale> resolveLocale(final HttpServletRequest request) {
+    public List<Locale> resolveLocale(final javax.servlet.http.HttpServletRequest request) {
         Enumeration<?> locales = request.getLocales();
-        ArrayList<Locale> localeList = new ArrayList<Locale>();
+        ArrayList<Locale> localeList = new ArrayList<>();
         while (locales.hasMoreElements()) {
             localeList.add((Locale) locales.nextElement());
         }
         return localeList;
     }
+
+    /**
+     * @see org.apache.sling.i18n.RequestLocaleResolver#resolveLocale(jakarta.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public List<Locale> resolveLocale(jakarta.servlet.http.HttpServletRequest request) {
+        Enumeration<?> locales = request.getLocales();
+        ArrayList<Locale> localeList = new ArrayList<>();
+        while (locales.hasMoreElements()) {
+            localeList.add((Locale) locales.nextElement());
+        }
+        return localeList;
+    }
+
 }

--- a/src/main/java/org/apache/sling/i18n/RequestLocaleResolver.java
+++ b/src/main/java/org/apache/sling/i18n/RequestLocaleResolver.java
@@ -21,8 +21,6 @@ package org.apache.sling.i18n;
 import java.util.List;
 import java.util.Locale;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * The <code>RequestLocaleResolver</code> service interface may be implemented by a
  * service registered under this name to allow the resolution of the request
@@ -51,6 +49,26 @@ public interface RequestLocaleResolver {
      * @return The list of <code>Locale</code>s to use for internationalization
      *         of request processing
      */
-    List<Locale> resolveLocale(HttpServletRequest request);
+    List<Locale> resolveLocale(javax.servlet.http.HttpServletRequest request);
+
+    /**
+     * Return a non-<code>null</code> but possibly empty list of
+     * <code>Locale</code> instances to consider for localization of the current
+     * request. The list returned is assumed to be ordered by preference where
+     * the first entry is the preferred <code>Locale</code> and the last entry is
+     * the least preferred <code>Locale</code>.
+     * <p>
+     * Returning an empty list is equivalent to returning a singleton list whose
+     * single entry is the {@link ResourceBundleProvider#getDefaultLocale()}.
+     *
+     * @param request The <code>HttpServletRequest</code> providing hints
+     *            and information for the <code>Locale</code> resolution.
+     * @return The list of <code>Locale</code>s to use for internationalization
+     *         of request processing
+     * @since 2.3
+     */
+    default List<Locale> resolveLocale(jakarta.servlet.http.HttpServletRequest request) {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/src/main/java/org/apache/sling/i18n/package-info.java
+++ b/src/main/java/org/apache/sling/i18n/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("2.2.1")
+@org.osgi.annotation.versioning.Version("2.3.0")
 package org.apache.sling.i18n;
 
 

--- a/src/test/java/org/apache/sling/i18n/DefaultLocaleResolverTest.java
+++ b/src/test/java/org/apache/sling/i18n/DefaultLocaleResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.i18n;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ *
+ */
+public class DefaultLocaleResolverTest {
+
+    private DefaultLocaleResolver localeResolver = new DefaultLocaleResolver();
+
+    /**
+     * Test method for {@link org.apache.sling.i18n.DefaultLocaleResolver#resolveLocale(org.apache.sling.api.SlingHttpServletRequest)}.
+     */
+    @Test
+    public void testResolveLocaleSlingHttpServletRequest() {
+        SlingHttpServletRequest req = Mockito.mock(SlingHttpServletRequest.class);
+        Mockito.doReturn(Collections.enumeration(Arrays.asList(Locale.ENGLISH, Locale.GERMAN)))
+            .when(req).getLocales();
+        List<Locale> locales = localeResolver.resolveLocale(req);
+        assertNotNull(locales);
+        assertEquals(2, locales.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.i18n.DefaultLocaleResolver#resolveLocale(javax.servlet.http.HttpServletRequest)}.
+     */
+    @Test
+    public void testResolveLocaleHttpServletRequest() {
+        javax.servlet.http.HttpServletRequest req = Mockito.mock(javax.servlet.http.HttpServletRequest.class);
+        Mockito.doReturn(Collections.enumeration(Arrays.asList(Locale.ENGLISH, Locale.GERMAN)))
+            .when(req).getLocales();
+        List<Locale> locales = localeResolver.resolveLocale(req);
+        assertNotNull(locales);
+        assertEquals(2, locales.size());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.i18n.DefaultLocaleResolver#resolveLocale(jakarta.servlet.http.HttpServletRequest)}.
+     */
+    @Test
+    public void testResolveLocaleHttpServletRequest1() {
+        jakarta.servlet.http.HttpServletRequest req = Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+        Mockito.doReturn(Collections.enumeration(Arrays.asList(Locale.ENGLISH, Locale.GERMAN)))
+            .when(req).getLocales();
+        List<Locale> locales = localeResolver.resolveLocale(req);
+        assertNotNull(locales);
+        assertEquals(2, locales.size());
+    }
+
+}

--- a/src/test/java/org/apache/sling/i18n/RequestLocaleResolverTest.java
+++ b/src/test/java/org/apache/sling/i18n/RequestLocaleResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.i18n;
+
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ *
+ */
+public class RequestLocaleResolverTest {
+
+    /**
+     * Test method for {@link org.apache.sling.i18n.RequestLocaleResolver#resolveLocale(jakarta.servlet.http.HttpServletRequest)}.
+     */
+    @Test
+    public void testResolveLocaleHttpServletRequest() {
+        RequestLocaleResolver requestLocaleResolver = new RequestLocaleResolver() {
+            @Override
+            public List<Locale> resolveLocale(javax.servlet.http.HttpServletRequest request) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        jakarta.servlet.http.HttpServletRequest jakartaReq = Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+        assertThrows(UnsupportedOperationException.class, () -> requestLocaleResolver.resolveLocale(jakartaReq));
+    }
+
+}


### PR DESCRIPTION
provide a variant of the RequestLocaleResolver#resolveLocale call that accepts a jakarta.servlet.http.HttpServletRequest for use cases that have migrated to EE9 or later.