### PR TITLE
SLING-12315:  avoid new registrations during deactivation

### DIFF
--- a/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.i18n.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
@@ -215,6 +216,6 @@ public class ConcurrentJcrResourceBundleLoadingTest {
     @Test
     public void loadBundlesDuringDeactivateRace() {
         provider.deactivate();
-        provider.getResourceBundle(Locale.ENGLISH);
+        assertNotNull(provider.getResourceBundle(Locale.ENGLISH));
     }
 }

--- a/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
@@ -208,4 +208,13 @@ public class ConcurrentJcrResourceBundleLoadingTest {
         ResourceBundle english2 = provider.getResourceBundle(Locale.ENGLISH);
         assertNotSame(english2, english);
     }
+
+    /**
+     * Verify that no exception occurs if requests come in during deactivate
+     */
+    @Test
+    public void loadBundlesDuringDeactivateRace() {
+        provider.deactivate();
+        provider.getResourceBundle(Locale.ENGLISH);
+    }
 }


### PR DESCRIPTION
- use bundleContext as cancel flag during deactivation
- prevent new registration of resources during deactivation (necessary)
- prevent processing of new onChange events during deactivation (improvement)
- prevent scheduling of new bundle reloading jobs during deactivation (improvement)
- execute clearCache after setting bundleContext to null, to prevent new registration (improvement)