### PR TITLE
SLING-12455 Supporting locale having script tags

### DIFF
--- a/src/main/java/org/apache/sling/i18n/impl/JcrResourceBundleProvider.java
+++ b/src/main/java/org/apache/sling/i18n/impl/JcrResourceBundleProvider.java
@@ -604,7 +604,7 @@ public class JcrResourceBundleProvider
         } else if (!locale.getLanguage().equals(defaultLocale.getLanguage())) {
             return defaultLocale;
         }
-        // no more parents
+        // the default locale has no parent locale
         return null;
     }
 

--- a/src/main/java/org/apache/sling/i18n/impl/PotentialLanguageRootCheck.java
+++ b/src/main/java/org/apache/sling/i18n/impl/PotentialLanguageRootCheck.java
@@ -36,7 +36,7 @@ class PotentialLanguageRootCheck {
 
     public PotentialLanguageRootCheck(String baseName, Locale locale) {
         this.baseName = baseName;
-        this.localeString = locale.toString();
+        this.localeString = localeToString(locale);
         this.localeStringLower = localeString.toLowerCase();
         this.localeRFC4646String = toRFC4646String(locale);
         this.localeRFC4646StringLower = localeRFC4646String.toLowerCase();
@@ -70,6 +70,24 @@ class PotentialLanguageRootCheck {
 
     // Would be nice if Locale.toString() output RFC 4646, but it doesn't
     private static String toRFC4646String(Locale locale) {
-        return locale.toString().replace('_', '-');
+        return localeToString(locale).replace('_', '-');
+    }
+    
+    private static String localeToString(Locale locale) {
+        boolean country = !locale.getCountry().isEmpty();
+        boolean variant = !locale.getVariant().isEmpty();
+        boolean script = !locale.getScript().isEmpty();
+    
+        StringBuilder result = new StringBuilder(locale.getLanguage());
+        if (script) {
+            result.append('_').append(locale.getScript());
+        }
+        if (country) {
+           result.append('_').append(locale.getCountry());
+        }
+        if (variant) {
+            result.append('_').append(locale.getVariant());
+        }
+        return result.toString();
     }
 }

--- a/src/main/java/org/apache/sling/i18n/impl/PotentialLanguageRootCheck.java
+++ b/src/main/java/org/apache/sling/i18n/impl/PotentialLanguageRootCheck.java
@@ -68,22 +68,21 @@ class PotentialLanguageRootCheck {
         return match;
     }
 
-    // Would be nice if Locale.toString() output RFC 4646, but it doesn't
     private static String toRFC4646String(Locale locale) {
         return localeToString(locale).replace('_', '-');
     }
-    
+
     private static String localeToString(Locale locale) {
         boolean country = !locale.getCountry().isEmpty();
         boolean variant = !locale.getVariant().isEmpty();
         boolean script = !locale.getScript().isEmpty();
-    
+
         StringBuilder result = new StringBuilder(locale.getLanguage());
         if (script) {
             result.append('_').append(locale.getScript());
         }
         if (country) {
-           result.append('_').append(locale.getCountry());
+            result.append('_').append(locale.getCountry());
         }
         if (variant) {
             result.append('_').append(locale.getVariant());

--- a/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
@@ -234,19 +234,6 @@ public class ConcurrentJcrResourceBundleLoadingTest {
      */
     @Test
     public void clearCacheInterleavedWithRegistersClearsAllRBs() throws Exception {
-        final String SCRIPT_TAG = "hans";
-        final String VARIANT = "variant";
-        final Locale CHINESE_SCRIPT_LOCALE = new Locale.Builder()
-                .setLanguage(Locale.CHINA.getLanguage())
-                .setScript(SCRIPT_TAG)
-                .build();
-        final Locale CHINESE_SCRIPT_VARIANT_LOCALE = new Locale.Builder()
-                .setLanguage(Locale.CHINA.getLanguage())
-                .setRegion(Locale.CHINA.getCountry())
-                .setScript(SCRIPT_TAG)
-                .setVariant(VARIANT)
-                .build();
-
         Map<Locale, List<ResourceBundle>> rbLists = new ConcurrentHashMap<>();
         final Locale[] testLocales = {
             Locale.ENGLISH,
@@ -257,9 +244,7 @@ public class ConcurrentJcrResourceBundleLoadingTest {
             Locale.KOREAN,
             Locale.CHINESE,
             Locale.SIMPLIFIED_CHINESE,
-            Locale.TRADITIONAL_CHINESE,
-            CHINESE_SCRIPT_LOCALE,
-            CHINESE_SCRIPT_VARIANT_LOCALE
+            Locale.TRADITIONAL_CHINESE
         };
 
         final int numberOfThreads = 100;

--- a/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/ConcurrentJcrResourceBundleLoadingTest.java
@@ -234,6 +234,19 @@ public class ConcurrentJcrResourceBundleLoadingTest {
      */
     @Test
     public void clearCacheInterleavedWithRegistersClearsAllRBs() throws Exception {
+        final String SCRIPT_TAG = "hans";
+        final String VARIANT = "variant";
+        final Locale CHINESE_SCRIPT_LOCALE = new Locale.Builder()
+                .setLanguage(Locale.CHINA.getLanguage())
+                .setScript(SCRIPT_TAG)
+                .build();
+        final Locale CHINESE_SCRIPT_VARIANT_LOCALE = new Locale.Builder()
+                .setLanguage(Locale.CHINA.getLanguage())
+                .setRegion(Locale.CHINA.getCountry())
+                .setScript(SCRIPT_TAG)
+                .setVariant(VARIANT)
+                .build();
+
         Map<Locale, List<ResourceBundle>> rbLists = new ConcurrentHashMap<>();
         final Locale[] testLocales = {
             Locale.ENGLISH,
@@ -244,7 +257,9 @@ public class ConcurrentJcrResourceBundleLoadingTest {
             Locale.KOREAN,
             Locale.CHINESE,
             Locale.SIMPLIFIED_CHINESE,
-            Locale.TRADITIONAL_CHINESE
+            Locale.TRADITIONAL_CHINESE,
+            CHINESE_SCRIPT_LOCALE,
+            CHINESE_SCRIPT_VARIANT_LOCALE
         };
 
         final int numberOfThreads = 100;

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
@@ -235,5 +235,8 @@ public class JcrResourceBundleProviderTest {
         // Locale with language only
         locale = new Locale(Locale.CHINA.getLanguage());
         Assert.assertEquals(provider.getDefaultLocale(), provider.getParentLocale(locale));
+
+        // The parent of the default locale is null
+        Assert.assertNull(provider.getParentLocale(provider.getDefaultLocale()));
     }
 }

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
@@ -63,9 +63,19 @@ public class JcrResourceBundleProviderTest {
                 JcrResourceBundleProvider.toLocale("en_GB_variant1"));
 
         // parts after the variant are just ignored
-        Assert.assertEquals(
-                new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"),
-                JcrResourceBundleProvider.toLocale("en_GB_variant1_something"));
+        Assert.assertEquals(new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"), JcrResourceBundleProvider.toLocale("en_GB_variant1_something"));
+        
+        // language, script, country and variant being set
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1"));
+    
+        // parts after the variant are just ignored
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1_variant2"));
+    
+        // language, script and country being set
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn"));
     }
 
     @Test
@@ -86,9 +96,19 @@ public class JcrResourceBundleProviderTest {
                 JcrResourceBundleProvider.toLocale("en-GB-variant1"));
 
         // parts after the variant are just ignored
-        Assert.assertEquals(
-                new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"),
-                JcrResourceBundleProvider.toLocale("en-GB-variant1-something-else"));
+        Assert.assertEquals(new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"), JcrResourceBundleProvider.toLocale("en-GB-variant1-something-else"));
+        
+        // language, script, country and variant being set
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1"));
+    
+        // parts after the variant are just ignored
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1-variant2"));
+    
+        // language, script and country being set
+        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn"));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
@@ -67,6 +67,14 @@ public class JcrResourceBundleProviderTest {
                 new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"),
                 JcrResourceBundleProvider.toLocale("en_GB_variant1_something"));
 
+        // language and script being set
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setScript("hans")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh_hans"));
+
         // language, script, country and variant being set
         Assert.assertEquals(
                 new Locale.Builder()

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
@@ -63,19 +63,38 @@ public class JcrResourceBundleProviderTest {
                 JcrResourceBundleProvider.toLocale("en_GB_variant1"));
 
         // parts after the variant are just ignored
-        Assert.assertEquals(new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"), JcrResourceBundleProvider.toLocale("en_GB_variant1_something"));
-        
+        Assert.assertEquals(
+                new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"),
+                JcrResourceBundleProvider.toLocale("en_GB_variant1_something"));
+
         // language, script, country and variant being set
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1"));
-    
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .setVariant("variant1")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1"));
+
         // parts after the variant are just ignored
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1_variant2"));
-    
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .setVariant("variant1")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh_hans_cn_variant1_variant2"));
+
         // language, script and country being set
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), JcrResourceBundleProvider.toLocale("zh_hans_cn"));
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh_hans_cn"));
     }
 
     @Test
@@ -96,19 +115,38 @@ public class JcrResourceBundleProviderTest {
                 JcrResourceBundleProvider.toLocale("en-GB-variant1"));
 
         // parts after the variant are just ignored
-        Assert.assertEquals(new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"), JcrResourceBundleProvider.toLocale("en-GB-variant1-something-else"));
-        
+        Assert.assertEquals(
+                new Locale(Locale.UK.getLanguage(), Locale.UK.getCountry(), "variant1"),
+                JcrResourceBundleProvider.toLocale("en-GB-variant1-something-else"));
+
         // language, script, country and variant being set
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1"));
-    
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .setVariant("variant1")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1"));
+
         // parts after the variant are just ignored
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").setVariant("variant1").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1-variant2"));
-    
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .setVariant("variant1")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh-hans-cn-variant1-variant2"));
+
         // language, script and country being set
-        Assert.assertEquals(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), JcrResourceBundleProvider.toLocale("zh-hans-cn"));
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .build(),
+                JcrResourceBundleProvider.toLocale("zh-hans-cn"));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleProviderTest.java
@@ -103,6 +103,10 @@ public class JcrResourceBundleProviderTest {
                         .setScript("hans")
                         .build(),
                 JcrResourceBundleProvider.toLocale("zh_hans_cn"));
+
+        // for invalid country and invalid script, default country is assumed
+        Assert.assertEquals(
+                new Locale("en", Locale.getDefault().getCountry()), JcrResourceBundleProvider.toLocale("en_Han1"));
     }
 
     @Test
@@ -177,5 +181,59 @@ public class JcrResourceBundleProviderTest {
 
         // Lowercase Private use Country 'xa'
         Assert.assertEquals(new Locale(Locale.GERMAN.getLanguage(), "XA"), JcrResourceBundleProvider.toLocale("de_xa"));
+    }
+
+    @Test
+    public void testGetParentLocale() {
+        JcrResourceBundleProvider provider = new JcrResourceBundleProvider();
+        String variant = "variant1";
+        String script = "Hans";
+        // Locale with script and variant
+        Locale locale = new Locale.Builder()
+                .setLanguage(Locale.CHINA.getLanguage())
+                .setScript(script)
+                .setRegion(Locale.CHINA.getCountry())
+                .setVariant(variant)
+                .build();
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setScript(script)
+                        .setRegion(Locale.CHINA.getCountry())
+                        .build(),
+                provider.getParentLocale(locale));
+
+        // Locale with script and country
+        locale = new Locale.Builder()
+                .setLanguage(Locale.CHINA.getLanguage())
+                .setScript(script)
+                .setRegion(Locale.CHINA.getCountry())
+                .build();
+        Assert.assertEquals(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setScript(script)
+                        .build(),
+                provider.getParentLocale(locale));
+
+        // Locale with script only
+        locale = new Locale.Builder()
+                .setLanguage(Locale.CHINA.getLanguage())
+                .setScript(script)
+                .build();
+        Assert.assertEquals(new Locale(Locale.CHINA.getLanguage()), provider.getParentLocale(locale));
+
+        // Locale with variant only
+        locale = new Locale(Locale.CHINA.getLanguage(), Locale.CHINA.getCountry(), variant);
+        Assert.assertEquals(
+                new Locale(Locale.CHINA.getLanguage(), Locale.CHINA.getCountry()), provider.getParentLocale(locale));
+
+        // Locale with country only
+        locale = new Locale(Locale.CHINA.getLanguage(), Locale.CHINA.getCountry());
+        Assert.assertEquals(new Locale(Locale.CHINA.getLanguage()), provider.getParentLocale(locale));
+
+        // Locale with language only
+        locale = new Locale(Locale.CHINA.getLanguage());
+        Assert.assertEquals(provider.getDefaultLocale(), provider.getParentLocale(locale));
     }
 }

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleTest.java
@@ -108,6 +108,7 @@ public class JcrResourceBundleTest {
     public static final Map<String, Message> MESSAGES_EN = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_DASH_US = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_UNDERSCORE_UK = new LinkedHashMap<String, Message>();
+    public static final Map<String, Message> MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_UNDERSCORE_AU = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_DE_APPS = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_DE_BASENAME = new LinkedHashMap<String, Message>();
@@ -135,6 +136,8 @@ public class JcrResourceBundleTest {
         add(MESSAGES_EN_DASH_US, new Message("", "pigment", "color", false));
         add(MESSAGES_EN_UNDERSCORE_UK, new Message("", "pigment", "colour", false));
         add(MESSAGES_EN_UNDERSCORE_AU, new Message("", "pigment", "colour", false));
+    
+        add(MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN, new Message("", "pigment", "颜料", false));
 
         // 6. same as 1.-4., but different translations for overwriting into apps
         for (Message msg : MESSAGES_DE.values()) {
@@ -195,6 +198,14 @@ public class JcrResourceBundleTest {
             msg.add(enUnderscoreAU);
         }
         getSession().save();
+        
+        // some zh_hans_cn content
+        Node zhUnderscoreHansUnderscoreCN = i18n.addNode("zh_hans_cn", "nt:folder");
+        zhUnderscoreHansUnderscoreCN.addMixin("mix:language");
+        zhUnderscoreHansUnderscoreCN.setProperty("jcr:language", "zh_hans_cn");
+        for (Message msg : MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN.values()) {
+            msg.add(zhUnderscoreHansUnderscoreCN);
+        }
     }
 
     // ---------------------------------------------------------------< tests >
@@ -218,6 +229,12 @@ public class JcrResourceBundleTest {
 
         bundle = new JcrResourceBundle(new Locale("en", "au"), null, resolver, null, new PathFilter());
         for (Message msg : MESSAGES_EN_UNDERSCORE_AU.values()) {
+            assertEquals(msg.message, bundle.getString(msg.key));
+        }
+        
+        bundle = new JcrResourceBundle(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
+            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), null, resolver, null, new PathFilter());
+        for (Message msg : MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN.values()) {
             assertEquals(msg.message, bundle.getString(msg.key));
         }
     }

--- a/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleTest.java
+++ b/src/test/java/org/apache/sling/i18n/impl/JcrResourceBundleTest.java
@@ -108,7 +108,8 @@ public class JcrResourceBundleTest {
     public static final Map<String, Message> MESSAGES_EN = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_DASH_US = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_UNDERSCORE_UK = new LinkedHashMap<String, Message>();
-    public static final Map<String, Message> MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN = new LinkedHashMap<String, Message>();
+    public static final Map<String, Message> MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN =
+            new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_EN_UNDERSCORE_AU = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_DE_APPS = new LinkedHashMap<String, Message>();
     public static final Map<String, Message> MESSAGES_DE_BASENAME = new LinkedHashMap<String, Message>();
@@ -136,7 +137,7 @@ public class JcrResourceBundleTest {
         add(MESSAGES_EN_DASH_US, new Message("", "pigment", "color", false));
         add(MESSAGES_EN_UNDERSCORE_UK, new Message("", "pigment", "colour", false));
         add(MESSAGES_EN_UNDERSCORE_AU, new Message("", "pigment", "colour", false));
-    
+
         add(MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN, new Message("", "pigment", "颜料", false));
 
         // 6. same as 1.-4., but different translations for overwriting into apps
@@ -198,7 +199,7 @@ public class JcrResourceBundleTest {
             msg.add(enUnderscoreAU);
         }
         getSession().save();
-        
+
         // some zh_hans_cn content
         Node zhUnderscoreHansUnderscoreCN = i18n.addNode("zh_hans_cn", "nt:folder");
         zhUnderscoreHansUnderscoreCN.addMixin("mix:language");
@@ -231,9 +232,17 @@ public class JcrResourceBundleTest {
         for (Message msg : MESSAGES_EN_UNDERSCORE_AU.values()) {
             assertEquals(msg.message, bundle.getString(msg.key));
         }
-        
-        bundle = new JcrResourceBundle(new Locale.Builder().setLanguage(Locale.CHINA.getLanguage()).
-            setRegion(Locale.CHINA.getCountry()).setScript("hans").build(), null, resolver, null, new PathFilter());
+
+        bundle = new JcrResourceBundle(
+                new Locale.Builder()
+                        .setLanguage(Locale.CHINA.getLanguage())
+                        .setRegion(Locale.CHINA.getCountry())
+                        .setScript("hans")
+                        .build(),
+                null,
+                resolver,
+                null,
+                new PathFilter());
         for (Message msg : MESSAGES_ZH_UNDERSCORE_HANS_UNDERSCORE_CN.values()) {
             assertEquals(msg.message, bundle.getString(msg.key));
         }


### PR DESCRIPTION
JIRA https://issues.apache.org/jira/browse/SLING-12455 

`Improvement to support locale having script tag (<language><script><country>) in sling.`

Important Considerations :- 

- Fallback mechanism for handling script locales is from RFC standard stated here: https://www.rfc-editor.org/rfc/rfc4647#section-3.4

- Script tag code validation is done from Java platform, similar to language and country code validation.

- If script tag is not valid, execution fallbacks to old implementation behaviour, making it BC
